### PR TITLE
Removes div that wasn't being effectively removed by previous code

### DIFF
--- a/lib/google.js
+++ b/lib/google.js
@@ -39,7 +39,7 @@ var igoogle = function(query, start, callback) {
           item.href = item.link
         }
         
-        $(descElem).remove('div');
+        $(descElem).find('div').remove();
         item.description = $(descElem).text();
         
         links.push(item);


### PR DESCRIPTION
div.action-menu.ab_ctl was being included as part of item.description, which was causing descriptions to have 'Cached' before every description
