### PR TITLE
added UTF-8 encoding parameters to search URL

### DIFF
--- a/lib/google.js
+++ b/lib/google.js
@@ -10,7 +10,7 @@ var linkSel = 'h3.r a'
   , itemSel = 'li.g'
   , nextSel = 'td.b a span';
 
-var URL = 'http://www.google.com/search?hl=en&q=%s&start=%s&sa=N&num=%s';
+var URL = 'http://www.google.com/search?hl=en&q=%s&start=%s&sa=N&num=%s&ie=UTF-8&oe=UTF-8';
 
 function google(query, callback) {  
   igoogle(query, 0, callback);  


### PR DESCRIPTION
The response to requesting the previous URL appears to have an html doc with content-type of ISO-8859-1, which leads to special characters not being properly displayed. Added UTF-8 encoding to the request URL and now special characters are properly displayed in results
