### PR TITLE
Fixed search result title returning names of sublinks.

### DIFF
--- a/lib/google.js
+++ b/lib/google.js
@@ -31,7 +31,7 @@ var igoogle = function(query, start, callback) {
       $(itemSel).each(function(i, elem) {
         var linkElem = $(elem).find(linkSel)
           , descElem = $(elem).find(descSel)
-          , item = {title: $(linkElem).text(), link: null, description: null, href: null}
+          , item = {title: $(linkElem).first().text(), link: null, description: null, href: null}
           , qsObj = querystring.parse($(linkElem).attr('href'));
         
         if (qsObj['/url?q']) {


### PR DESCRIPTION
For example searching for "youtube" would return "YouTubeYouTubeMusicMoviesYou TubeBrowse channelsOne account. All of Google." as the title property. Now it only returns "YouTube".
