### PR TITLE
Fixing undef resp in error condition

### DIFF
--- a/lib/google.js
+++ b/lib/google.js
@@ -54,7 +54,7 @@ var igoogle = function(query, start, callback) {
       
       callback(null, nextFunc, links);
     } else {
-      callback(new Error('Error on response (' + resp.statusCode + '):' + err +" : " + body), null, null);
+      callback(new Error('Error on response' + (resp ? ' ('+resp.statusCode+')' : '') + ':' + err +" : " + body), null, null);
     }
   });
 }


### PR DESCRIPTION
When `err` is not `null`, `resp` can be `undefined` which is causing an exception
