### PR TITLE
Fix CSV quoting

### DIFF
--- a/bin/google
+++ b/bin/google
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 
-var program = require('commander')
-  , google = require('../lib/google')
+var program = require('commander'),
+    google = require('../lib/google'),
+    csv = require('fast-csv');
 
 program.version(require('../package').version)
   .option('-q, --query <query>', 'Search query.')
@@ -31,9 +32,13 @@ var nextCounter = 0;
 google(program.query, function(err, next, links){
   if (err) console.error(err)
 
-  links.forEach(function(link) {
-    console.log('"%s","%s","%s"', link.href, link.title, link.description)
-  })
+  csv.writeToString(links, {
+    transform: function(link) {
+      return [link.href, link.title, link.description];
+    }
+  }, function(err, data) {
+    console.log(data);
+  });
 
   if (nextCounter < program.pages - 1) {
     nextCounter += 1;

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   "dependencies": {
     "cheerio": "~0.10.8",
     "request": "2.12.x",
-    "commander": "~1.1.1"
+    "commander": "~1.1.1",
+    "fast-csv": "~0.5.2"
   },
   "devDependencies": {
     "mocha": "*",


### PR DESCRIPTION
The CSV generated by the command line program, does not quote quotes by
double quotes. The resulting CSV can not be used by other programs.

By using fast-csv library, this problem is avoided.
