### PR TITLE
added optional start parameter, enabling pagination

### DIFF
--- a/lib/google.js
+++ b/lib/google.js
@@ -14,11 +14,11 @@ var nextTextErrorMsg = 'Translate `google.nextText` option to selected language 
 
 // start parameter is optional
 function google (query, start, callback) {
-  var startIndex = 0; 
+  var startIndex = 0
   if (typeof callback === 'undefined') {
-    callback = start;
+    callback = start
   } else {
-    startIndex = start;
+    startIndex = start
   }
   igoogle(query, startIndex, callback)
 }

--- a/lib/google.js
+++ b/lib/google.js
@@ -12,8 +12,15 @@ var URL = 'http://www.google.%s/search?hl=%s&q=%s&start=%s&sa=N&num=%s&ie=UTF-8&
 
 var nextTextErrorMsg = 'Translate `google.nextText` option to selected language to detect next results link.'
 
-function google (query, callback) {
-  igoogle(query, 0, callback)
+// start parameter is optional
+function google (query, start, callback) {
+  var startIndex = 0; 
+  if (typeof callback === 'undefined') {
+    callback = start;
+  } else {
+    startIndex = start;
+  }
+  igoogle(query, startIndex, callback)
 }
 
 google.resultsPerPage = 10

--- a/test/google.test.js
+++ b/test/google.test.js
@@ -132,4 +132,25 @@ describe('+ google()', function () {
 
     })
   })
+
+  describe('when start is set', function () {
+    it('optional start parameter should return search results', function (done) {
+      var allLinks = []
+      var query = 'Microsoft'
+      var timeFrame = 'm'
+
+      var finished = function () {
+        assert(allLinks.length === 10)
+        done()
+      }
+
+      google.resultsPerPage = 10
+      google.timeSpan = timeFrame
+      google(query, 2, function (err, next, links) {
+        assert.ifError(err)
+        allLinks = allLinks.concat(links)
+        finished()
+      })
+    })
+  })
 })


### PR DESCRIPTION
This pull requests adds an optional starting index for google requests. You can set the number of results by which you want your query to be offset. To use it, change syntax from:

```javascript
google ('node.js best practices',  callback) 
```
to: 
```javascript
google ('node.js best practices',  10, callback) 
```